### PR TITLE
Jazzy + docker cleanup

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        DISTRO: [jammy]
+        DISTRO: [noble]
         TOOLCHAIN: [gcc]
     steps:
       - name: Checkout Repo

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -90,24 +90,11 @@ jobs:
               python${{ matrix.python_version }} -m venv /tmp/buildenv
               source /tmp/buildenv/bin/activate
 
-              pip install --upgrade pip ninja scikit-build-core auditwheel build wheel catkin_pkg pyyaml
+              pip install --upgrade pip ninja scikit-build-core auditwheel build catkin_pkg pyyaml
 
               python -m build --wheel --no-isolation -Cbuild-dir=/ros_ws/package/build
 
-              # Force auditwheel to bundle the Fast DDS RMW implementation.
-              # ROS loads RMW plugins via dlopen at runtime, which auditwheel cannot
-              # detect. Adding librmw_fastrtps_cpp.so as a NEEDED entry on the wheel's
-              # .so files makes auditwheel treat it as a direct dep and bundle it plus
-              # its transitive deps (fastrtps, fastcdr, foonathan_memory, ...).
-              WHEEL_FILE=\$(ls /ros_ws/dist/*${{ matrix.python_tag }}*.whl)
-              UNPACK_DIR=\$(mktemp -d)
-              wheel unpack -d \$UNPACK_DIR \$WHEEL_FILE
-              find \$UNPACK_DIR -name '*.so*' -type f -exec patchelf --add-needed librmw_fastrtps_cpp.so {} +
-              rm \$WHEEL_FILE
-              wheel pack -d /ros_ws/dist/ \$UNPACK_DIR/*/
-              rm -rf \$UNPACK_DIR
-
-              LD_LIBRARY_PATH=\$(find /ros_ws/package/build -name '*.so*' -exec dirname {} + | sort -u | tr '\n' ':'):/opt/ros/jazzy/lib:\$LD_LIBRARY_PATH \
+              LD_LIBRARY_PATH=\$(find /ros_ws/package/build -name '*.so*' -exec dirname {} + | sort -u | tr '\n' ':'):\$LD_LIBRARY_PATH \
               auditwheel repair /ros_ws/dist/*${{ matrix.python_tag }}*.whl -w /ros_ws/dist/auditwheel/
             "
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -90,11 +90,24 @@ jobs:
               python${{ matrix.python_version }} -m venv /tmp/buildenv
               source /tmp/buildenv/bin/activate
 
-              pip install --upgrade pip ninja scikit-build-core auditwheel build catkin_pkg pyyaml
+              pip install --upgrade pip ninja scikit-build-core auditwheel build wheel catkin_pkg pyyaml
 
               python -m build --wheel --no-isolation -Cbuild-dir=/ros_ws/package/build
 
-              LD_LIBRARY_PATH=\$(find /ros_ws/package/build -name '*.so*' -exec dirname {} + | sort -u | tr '\n' ':'):\$LD_LIBRARY_PATH \
+              # Force auditwheel to bundle the Fast DDS RMW implementation.
+              # ROS loads RMW plugins via dlopen at runtime, which auditwheel cannot
+              # detect. Adding librmw_fastrtps_cpp.so as a NEEDED entry on the wheel's
+              # .so files makes auditwheel treat it as a direct dep and bundle it plus
+              # its transitive deps (fastrtps, fastcdr, foonathan_memory, ...).
+              WHEEL_FILE=\$(ls /ros_ws/dist/*${{ matrix.python_tag }}*.whl)
+              UNPACK_DIR=\$(mktemp -d)
+              wheel unpack -d \$UNPACK_DIR \$WHEEL_FILE
+              find \$UNPACK_DIR -name '*.so*' -type f -exec patchelf --add-needed librmw_fastrtps_cpp.so {} +
+              rm \$WHEEL_FILE
+              wheel pack -d /ros_ws/dist/ \$UNPACK_DIR/*/
+              rm -rf \$UNPACK_DIR
+
+              LD_LIBRARY_PATH=\$(find /ros_ws/package/build -name '*.so*' -exec dirname {} + | sort -u | tr '\n' ':'):/opt/ros/jazzy/lib:\$LD_LIBRARY_PATH \
               auditwheel repair /ros_ws/dist/*${{ matrix.python_tag }}*.whl -w /ros_ws/dist/auditwheel/
             "
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -56,6 +56,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - python_version: "3.10"
+            python_tag: "cp310"
+            ubuntu_test: "22.04"
           - python_version: "3.12"
             python_tag: "cp312"
             ubuntu_test: "24.04"
@@ -113,6 +116,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - python_version: "3.10"
+            python_tag: "cp310"
+            ubuntu_version: "22.04"
           - python_version: "3.12"
             python_tag: "cp312"
             ubuntu_version: "24.04"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -56,9 +56,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python_version: "3.10"
-            python_tag: "cp310"
-            ubuntu_test: "22.04"
           - python_version: "3.12"
             python_tag: "cp312"
             ubuntu_test: "24.04"
@@ -116,9 +113,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python_version: "3.10"
-            python_tag: "cp310"
-            ubuntu_version: "22.04"
           - python_version: "3.12"
             python_tag: "cp312"
             ubuntu_version: "24.04"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -84,7 +84,7 @@ jobs:
             -w /ros_ws \
             ghcr.io/tumftm/pointcloudcrafter:latest \
             -c "
-              source /opt/ros/humble/setup.bash
+              source /opt/ros/jazzy/setup.bash
 
               apt-get update && apt-get install -y software-properties-common patchelf
               add-apt-repository -y ppa:deadsnakes/ppa

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -14,6 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - python_version: "3.10"
+            python_tag: "cp310"
+            ubuntu_test: "22.04"
           - python_version: "3.12"
             python_tag: "cp312"
             ubuntu_test: "24.04"
@@ -71,6 +74,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - python_version: "3.10"
+            python_tag: "cp310"
+            ubuntu_version: "22.04"
           - python_version: "3.12"
             python_tag: "cp312"
             ubuntu_version: "24.04"

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -14,9 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python_version: "3.10"
-            python_tag: "cp310"
-            ubuntu_test: "22.04"
           - python_version: "3.12"
             python_tag: "cp312"
             ubuntu_test: "24.04"
@@ -74,9 +71,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python_version: "3.10"
-            python_tag: "cp310"
-            ubuntu_version: "22.04"
           - python_version: "3.12"
             python_tag: "cp312"
             ubuntu_version: "24.04"

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -42,7 +42,7 @@ jobs:
             -w /ros_ws \
             ghcr.io/tumftm/pointcloudcrafter:latest \
             -c "
-              source /opt/ros/humble/setup.bash
+              source /opt/ros/jazzy/setup.bash
 
               apt-get update && apt-get install -y software-properties-common patchelf
               add-apt-repository -y ppa:deadsnakes/ppa

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A toolkit for extracting, manipulating, and evaluating point clouds and 3D spati
 
 [![Linux](https://img.shields.io/badge/os-linux-blue.svg)](https://www.linux.org/)
 [![Docker](https://badgen.net/badge/icon/docker?icon=docker&label)](https://www.docker.com/)
-[![ROS2humble](https://img.shields.io/badge/ros2-humble-blue.svg)](https://docs.ros.org/en/humble/index.html)
+[![ROS2jazzy](https://img.shields.io/badge/ros2-jazzy-blue.svg)](https://docs.ros.org/en/jazzy/index.html)
 [![PyPI](https://github.com/TUMFTM/PointCloudCrafter/actions/workflows/pypi.yml/badge.svg)](https://github.com/TUMFTM/PointCloudCrafter/actions/workflows/pypi.yml)
 [![docs](https://github.com/TUMFTM/PointCloudCrafter/actions/workflows/docs.yml/badge.svg)](https://github.com/TUMFTM/PointCloudCrafter/actions/workflows/docs.yml)
 ![Tested on](https://img.shields.io/badge/Tested%20on-Ubuntu%2022.04%20%7C%2024.04-E95420?logo=ubuntu&logoColor=white)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,7 +70,7 @@ RUN /bin/bash -c '. /opt/ros/$ROS_DISTRO/setup.bash && \
 # Set entrypoint by sourcing overlay workspace
 RUN echo 'source "/opt/ros/$ROS_DISTRO/setup.bash"' >> /root/.bashrc && \
     echo '. /ros_ws/install/setup.bash' >> /root/.bashrc && \
-    echo '#!/bin/bash\nset -e\n\n# setup ros environment\nsource "/opt/ros/$ROS_DISTRO/setup.bash"\n. /ros_ws/install/setup.bash\nexec "$@"' > /ros_entrypoint.sh && \
+    printf '#!/bin/bash\nset -e\n\n# setup ros environment\nsource "/opt/ros/$ROS_DISTRO/setup.bash"\n. /ros_ws/install/setup.bash\nexec "$@"\n' > /ros_entrypoint.sh && \
     chmod +x /ros_entrypoint.sh
 
 ENTRYPOINT ["/ros_entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,41 @@
-ARG ROS_DISTRO=humble
-FROM ros:${ROS_DISTRO}
+ARG UBUNTU_VERSION=24.04
+FROM ubuntu:${UBUNTU_VERSION}
 
+ARG ROS_DISTRO=jazzy
+ARG TZ=Europe/Berlin
+
+# Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
+ENV ROS_DISTRO=${ROS_DISTRO}
+ENV TZ=${TZ}
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV ROS_PYTHON_VERSION=3
+ENV RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity} {time}]: {message}"
+
+# Install necessary dependencies
+RUN apt-get update && apt-get install -y \
+  locales \
+  curl \
+  gnupg2 \
+  lsb-release \
+  ca-certificates \
+  gpg \
+  wget && \
+  locale-gen en_US en_US.UTF-8 && \
+  update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 && \
+  export LANG=en_US.UTF-8 && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add ROS 2 GPG key and repository
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') && \
+  curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${VERSION_CODENAME})_all.deb" && \
+  dpkg -i /tmp/ros2-apt-source.deb
 
 # Install dependencies
 RUN apt-get update && apt-get install -y -q --no-install-recommends \
-    wget \
-    curl \
     vim \
     build-essential \
-    ca-certificates \
-    gnupg2 \
-    lsb-release \
-    python3-pip \
-    python3-tk \
-    python3-build \
-    python3-colcon-common-extensions \
     patchelf \
     git \
     git-lfs \
@@ -24,12 +44,20 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
     apt-utils \
     libpcl-dev \
     libfmt-dev \
+    ros-${ROS_DISTRO}-ros-base \
     ros-${ROS_DISTRO}-pcl-conversions \
     ros-${ROS_DISTRO}-rosbag2-cpp \
     ros-${ROS_DISTRO}-rosbag2-storage-mcap \
+    cpplint \
+    clang-format \
+    gdb \
+    python3-pip \
+    python3-tk \
+    python3-build \
+    python3-colcon-common-extensions \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pip ninja scikit-build-core auditwheel
+RUN pip3 install --upgrade ninja scikit-build-core auditwheel --break-system-packages
 
 WORKDIR /ros_ws
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get update && apt-get install -y \
 # Add ROS 2 GPG key and repository
 RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') && \
   curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${VERSION_CODENAME})_all.deb" && \
-  dpkg -i /tmp/ros2-apt-source.deb
+  dpkg -i /tmp/ros2-apt-source.deb && \
+  rm -f /tmp/ros2-apt-source.deb
 
 # Install dependencies
 RUN apt-get update && apt-get install -y -q --no-install-recommends \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ENV ROS_PYTHON_VERSION=3
 ENV RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity} {time}]: {message}"
 
 # Install necessary dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
   locales \
   curl \
   gnupg2 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
     libpcl-dev \
     libfmt-dev \
     ros-${ROS_DISTRO}-ros-base \
+    ros-${ROS_DISTRO}-rmw-fastrtps-cpp \
     ros-${ROS_DISTRO}-pcl-conversions \
     ros-${ROS_DISTRO}-rosbag2-cpp \
     ros-${ROS_DISTRO}-rosbag2-storage-mcap \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -30,7 +30,8 @@ RUN apt-get update && apt-get install -y \
 # Add ROS 2 GPG key and repository
 RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') && \
   curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${VERSION_CODENAME})_all.deb" && \
-  dpkg -i /tmp/ros2-apt-source.deb
+  dpkg -i /tmp/ros2-apt-source.deb && \
+  rm -f /tmp/ros2-apt-source.deb
 
 # Install dependencies
 RUN apt-get update && apt-get install -y -q --no-install-recommends \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -14,7 +14,7 @@ ENV ROS_PYTHON_VERSION=3
 ENV RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity} {time}]: {message}"
 
 # Install necessary dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
   locales \
   curl \
   gnupg2 \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -45,6 +45,7 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
     libpcl-dev \
     libfmt-dev \
     ros-${ROS_DISTRO}-ros-base \
+    ros-${ROS_DISTRO}-rmw-fastrtps-cpp \
     ros-${ROS_DISTRO}-pcl-conversions \
     ros-${ROS_DISTRO}-rosbag2-cpp \
     ros-${ROS_DISTRO}-rosbag2-storage-mcap \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,21 +1,41 @@
-ARG ROS_DISTRO=humble
-FROM ros:${ROS_DISTRO}
+ARG UBUNTU_VERSION=24.04
+FROM ubuntu:${UBUNTU_VERSION}
 
+ARG ROS_DISTRO=jazzy
+ARG TZ=Europe/Berlin
+
+# Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
+ENV ROS_DISTRO=${ROS_DISTRO}
+ENV TZ=${TZ}
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV ROS_PYTHON_VERSION=3
+ENV RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity} {time}]: {message}"
+
+# Install necessary dependencies
+RUN apt-get update && apt-get install -y \
+  locales \
+  curl \
+  gnupg2 \
+  lsb-release \
+  ca-certificates \
+  gpg \
+  wget && \
+  locale-gen en_US en_US.UTF-8 && \
+  update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 && \
+  export LANG=en_US.UTF-8 && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add ROS 2 GPG key and repository
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') && \
+  curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${VERSION_CODENAME})_all.deb" && \
+  dpkg -i /tmp/ros2-apt-source.deb
 
 # Install dependencies
 RUN apt-get update && apt-get install -y -q --no-install-recommends \
-    wget \
-    curl \
     vim \
     build-essential \
-    ca-certificates \
-    gnupg2 \
-    lsb-release \
-    python3-pip \
-    python3-tk \
-    python3-build \
-    python3-colcon-common-extensions \
     patchelf \
     git \
     git-lfs \
@@ -24,15 +44,20 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
     apt-utils \
     libpcl-dev \
     libfmt-dev \
+    ros-${ROS_DISTRO}-ros-base \
     ros-${ROS_DISTRO}-pcl-conversions \
     ros-${ROS_DISTRO}-rosbag2-cpp \
     ros-${ROS_DISTRO}-rosbag2-storage-mcap \
     cpplint \
     clang-format \
     gdb \
+    python3-pip \
+    python3-tk \
+    python3-build \
+    python3-colcon-common-extensions \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pip ninja scikit-build-core auditwheel
+RUN pip3 install --upgrade ninja scikit-build-core auditwheel --break-system-packages
 
 WORKDIR /ros_ws
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 [![Linux](https://img.shields.io/badge/os-linux-blue.svg)](https://www.linux.org/)
 [![Docker](https://badgen.net/badge/icon/docker?icon=docker&label)](https://www.docker.com/)
-[![ROS2humble](https://img.shields.io/badge/ros2-humble-blue.svg)](https://docs.ros.org/en/humble/index.html)
+[![ROS2jazzy](https://img.shields.io/badge/ros2-jazzy-blue.svg)](https://docs.ros.org/en/jazzy/index.html)
 [![PyPI](https://github.com/TUMFTM/PointCloudCrafter/actions/workflows/pypi.yml/badge.svg)](https://github.com/TUMFTM/PointCloudCrafter/actions/workflows/pypi.yml)
 [![docs](https://github.com/TUMFTM/PointCloudCrafter/actions/workflows/docs.yml/badge.svg)](https://github.com/TUMFTM/PointCloudCrafter/actions/workflows/docs.yml)
 ![Tested on](https://img.shields.io/badge/Tested%20on-Ubuntu%2022.04%20%7C%2024.04-E95420?logo=ubuntu&logoColor=white)

--- a/package/bake_libs.sh
+++ b/package/bake_libs.sh
@@ -3,14 +3,14 @@
 PREFIX=$1
 DEST_LIB="$PREFIX/lib"
 DEST_SHARE="$PREFIX/share"
-ROS_PATH="/opt/ros/humble"
+ROS_PATH="/opt/ros/jazzy"
 
 # TODO(ga58lar): find a way to automate this
 # Manual copy plugins, which are not detected by auditwheel
-cp /opt/ros/humble/lib/librmw_fastrtps_*.so* "$DEST_LIB/"
-cp /opt/ros/humble/lib/librosbag2_storage_default_plugins.so* "$DEST_LIB/"
-cp /opt/ros/humble/lib/librosbag2_storage_mcap.so* "$DEST_LIB/"
-cp /opt/ros/humble/lib/libfast*.so* "$DEST_LIB/"
+cp /opt/ros/jazzy/lib/librmw_fastrtps_*.so* "$DEST_LIB/"
+cp /opt/ros/jazzy/lib/librosbag2_storage_default_plugins.so* "$DEST_LIB/"
+cp /opt/ros/jazzy/lib/librosbag2_storage_mcap.so* "$DEST_LIB/"
+cp /opt/ros/jazzy/lib/libfast*.so* "$DEST_LIB/"
 
 # Copy full ament index
 if [ -d "$ROS_PATH/share/ament_index" ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pointcloudcrafter"
-version = "1.2.4"
+version = "1.2.5"
 description = "Tools for Handling, Manipulating and Analyzing of Point Clouds"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pointcloudcrafter"
-version = "1.2.5"
+version = "1.3.4"
 description = "Tools for Handling, Manipulating and Analyzing of Point Clouds"
 readme = "README.md"
 authors = [

--- a/utils/rosbag_reader.hpp
+++ b/utils/rosbag_reader.hpp
@@ -140,11 +140,11 @@ public:
 
       // Get the first message time
       if (first_msg_time < 0) {
-        first_msg_time = bag_msg->time_stamp;
+        first_msg_time = bag_msg->send_timestamp;
       }
 
       // Log progress
-      double time_done = static_cast<double>((bag_msg->time_stamp - first_msg_time) / 1e9);
+      double time_done = static_cast<double>((bag_msg->send_timestamp - first_msg_time) / 1e9);
       RCLCPP_INFO_THROTTLE(
         logger_, wall_clock, 1000, "Processed %.3f sec of bag [% 5.1f%%]", time_done,
         100 * time_done / total_duration);


### PR DESCRIPTION
- upgraded ros-version to jazzy -> relevant for bag-reader of pointcloudcrafter rosbag, which deserializes rosbag-messages and now has to use the newly introduced send- and recv-timestamps
- cleaned up docker images to only install ros-base and save storage