### PR TITLE
add ror of TUM to affiliation in paper

### DIFF
--- a/docs/paper.md
+++ b/docs/paper.md
@@ -17,6 +17,7 @@ authors:
 affiliations:
  - name: Institute of Automotive Technology, Department of Mobility System Engineering, School of Engineering and Design, Technical University of Munich, Germany.
    index: 1
+   ror: "02kkvpp62"
 date: 25.January 2026  
 bibliography: paper.bib
 


### PR DESCRIPTION
This PR adds the TUM ROR to the affiliation stated in the paper.
This is an optional requirement by JOSS: https://joss.readthedocs.io/en/latest/paper.html#affiliations
Note that the ROR only identifies the top-level organization not the specific institute.